### PR TITLE
Add body parser limit option to app

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,11 +20,16 @@ export type MiddleWareConfig = {
   showErrorDetail?: boolean
 }
 
+export type AppOptions = {
+  express?: () => Express;
+  jsonParserLimit?: string | number
+}
+
 /**
  * Systemic component that creates and configures an Express app
  * @param options optionally a function that creates a basic Express app can be passed into the component
  */
-export function app(options?: { express?: () => Express }): CallbackComponent<Express, { config?: AppConfig; logger?: any }>
+export function app(options?: AppOptions): CallbackComponent<Express, { config?: AppConfig; logger?: any }>
 
 /**
  * Starts the Express server

--- a/lib/app.js
+++ b/lib/app.js
@@ -4,6 +4,9 @@ const debug = require('debug')('systemic-express:app')
 const bodyParser = require('body-parser')
 const { errorMiddleware } = require('./errorMiddleware')
 
+// default value from body-parser lib
+const defaultJsonParserLimit = '100kb'
+
 module.exports = function(options) {
     const express = get(options, 'express') || require('express')
     let config
@@ -18,8 +21,9 @@ module.exports = function(options) {
     }
 
     function start(cb) {
+        const jsonParserLimit = options.jsonParserLimit || defaultJsonParserLimit
         const app = express()
-        const jsonParser = bodyParser.json()
+        const jsonParser = bodyParser.json({ limit: jsonParserLimit })
 
         app.locals.logger = logger
         app.use(jsonParser)

--- a/lib/app.js
+++ b/lib/app.js
@@ -21,7 +21,7 @@ module.exports = function(options) {
     }
 
     function start(cb) {
-        const jsonParserLimit = options.jsonParserLimit || defaultJsonParserLimit
+        const jsonParserLimit = options?.jsonParserLimit || defaultJsonParserLimit
         const app = express()
         const jsonParser = bodyParser.json({ limit: jsonParserLimit })
 

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -1,6 +1,5 @@
 const { describe, it } = require("mocha");
 const request = require("supertest");
-const express = require("express");
 
 const System = require("systemic");
 


### PR DESCRIPTION
We get en error in the UMC api about a request payload being too large. This can be solved by increasing the body limit for json body parser.

See issue: https://github.com/infinitaslearning/user-managed-content/issues/556